### PR TITLE
Changed typings file to use default

### DIFF
--- a/dist/cronstrue.d.ts
+++ b/dist/cronstrue.d.ts
@@ -1,2 +1,2 @@
 import { ExpressionDescriptor } from "./expressionDescriptor";
-export = ExpressionDescriptor;
+export default ExpressionDescriptor;


### PR DESCRIPTION
Updated the typings file to use `default` instead of `=` as this seems to be the way to export modules. Was getting errors trying to use this package with Angular-CLI.

Closes #17