### PR TITLE
Fix single minute, list of hour with interval

### DIFF
--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -136,7 +136,7 @@ export class ExpressionDescriptor {
       );
     } else if (
       hourExpression.indexOf(",") > -1 &&
-      hourExpression.indexOf("-") == -1 &&
+      hourExpression.indexOf("-") == -1 && hourExpression.indexOf("/") == -1 &&
       !StringUtilities.containsAny(minuteExpression, ExpressionDescriptor.specialCharacters)
     ) {
       //hours list with single minute (i.e. 30 6,14,16)

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -408,6 +408,13 @@ describe("Cronstrue", function() {
         "At 02:00 AM and 04:00 PM, on day 1, 8, 15, and 22 of the month, only on Monday and Tuesday"
       );
     });
+
+    it("0 */4,6 * * * ", function() {
+      assert.equal(
+        construe.toString(this.test.title),
+        "Every 4,6 hours"
+      );
+    });
   });
 
   describe("verbose", function() {


### PR DESCRIPTION
This fixes expressions that contain a specific minute and list of hours but where as least one of the hours items contains a segment (i.e. `0 */4,6 * * *`)

Fixes #50