### PR TITLE
Fixed missing translation for Russian translation

### DIFF
--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -86,7 +86,7 @@ export class ru implements Locale {
     return ", каждый день";
   }
   commaEveryX0DaysOfTheWeek(s?: string) {
-    return getPhraseByNumber(s, ["", ", каждые %s дня недели", ", каждые %s дней недели"]);
+    return getPhraseByNumber(s, [", каждый %s день недели", ", каждые %s дня недели", ", каждые %s дней недели"]);
   }
   commaX0ThroughX1(s?: string) {
     return s && (s[0] == "2" || s[0] == "3") ? ", со %s по %s" : ", с %s по %s";

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -264,6 +264,13 @@ describe("i18n", function () {
         "Каждые 5 минут, с 15:00 по 15:59, с понедельника по пятницу"
       );
     });
+
+    it("* * * * */31", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "ru" }),
+        "Каждую минуту, каждый 31 день недели"
+      );
+    });
   });
 
   describe("tr", function () {


### PR DESCRIPTION
In English, the value is displayed correctly:
<img width="639" height="679" alt="image" src="https://github.com/user-attachments/assets/ddb3cfa8-bd8c-4a24-8f85-3c9d8565961b" />

but not in Russian:
<img width="639" height="679" alt="image" src="https://github.com/user-attachments/assets/b475adb4-b8d6-41a8-8b5c-8fadc5c0a27f" />
