### PR TITLE
Add Norwegian Nynorsk (nn) locale

### DIFF
--- a/src/i18n/allLocales.ts
+++ b/src/i18n/allLocales.ts
@@ -8,6 +8,7 @@ export { id } from "./locales/id"; // Indonesia
 export { ko } from "./locales/ko"; // Korean
 export { nl } from "./locales/nl"; // Dutch
 export { nb } from "./locales/nb"; // Norwegian
+export { nn } from "./locales/nn"; // Norwegian (Nynorsk)
 export { sv } from "./locales/sv"; // Swedish
 export { pl } from "./locales/pl"; // Polish
 export { pt_BR } from "./locales/pt_BR"; // Portuguese (Brazil)

--- a/src/i18n/locales/nn.ts
+++ b/src/i18n/locales/nn.ts
@@ -1,0 +1,178 @@
+// Norwegian (Nynorsk)
+
+import { Locale } from "../locale";
+export class nn implements Locale {
+  atX0SecondsPastTheMinuteGt20(): string|null {
+    return null;
+  }
+  atX0MinutesPastTheHourGt20(): string|null {
+    return null;
+  }
+  commaMonthX0ThroughMonthX1(): string|null {
+    return null;
+  }
+  commaYearX0ThroughYearX1(): string|null {
+    return null;
+  }
+  use24HourTimeFormatByDefault() {
+    return true;
+  }
+  anErrorOccuredWhenGeneratingTheExpressionD() {
+    return "Ein feil oppstod ved generering av uttrykksskildring. Sjekk cron-syntaksen.";
+  }
+  at() {
+    return "Kl.";
+  }
+  atSpace() {
+    return "Kl.";
+  }
+  atX0() {
+    return "på %s";
+  }
+  atX0MinutesPastTheHour() {
+    return "på %s minutt etter timen";
+  }
+  atX0SecondsPastTheMinute() {
+    return "på %s sekund etter minuttet";
+  }
+  betweenX0AndX1() {
+    return "mellom %s og %s";
+  }
+  commaBetweenDayX0AndX1OfTheMonth() {
+    return ", mellom dag %s og %s av månaden";
+  }
+  commaEveryDay() {
+    return ", kvar dag";
+  }
+  commaEveryX0Days() {
+    return ", kvar %s dag";
+  }
+  commaEveryX0DaysOfTheWeek() {
+    return ", kvar %s vekedag";
+  }
+  commaEveryX0Months() {
+    return ", kvar %s månad";
+  }
+  commaEveryX0Years() {
+    return ", kvart %s år";
+  }
+  commaOnDayX0OfTheMonth() {
+    return ", på dag %s av månaden";
+  }
+  commaOnlyInX0() {
+    return ", berre i %s";
+  }
+  commaOnlyOnX0() {
+    return ", på %s";
+  }
+  commaAndOnX0() {
+    return ", og på %s";
+  }
+  commaOnThe() {
+    return ", på ";
+  }
+  commaOnTheLastDayOfTheMonth() {
+    return ", på den siste dagen i månaden";
+  }
+  commaOnTheLastWeekdayOfTheMonth() {
+    return ", den siste vekedagen i månaden";
+  }
+  commaDaysBeforeTheLastDayOfTheMonth() {
+    return ", %s dagar før den siste dagen i månaden";
+  }
+  commaOnTheLastX0OfTheMonth() {
+    return ", på den siste %s av månaden";
+  }
+  commaOnTheX0OfTheMonth() {
+    return ", på den %s av månaden";
+  }
+  commaX0ThroughX1() {
+    return ", %s til og med %s";
+  }
+  commaAndX0ThroughX1() {
+    return ", og %s til og med %s";
+  }
+  everyHour() {
+    return "kvar time";
+  }
+  everyMinute() {
+    return "kvart minutt";
+  }
+  everyMinuteBetweenX0AndX1() {
+    return "Kvart minutt mellom %s og %s";
+  }
+  everySecond() {
+    return "kvart sekund";
+  }
+  everyX0Hours() {
+    return "kvar %s time";
+  }
+  everyX0Minutes() {
+    return "kvart %s minutt";
+  }
+  everyX0Seconds() {
+    return "kvart %s sekund";
+  }
+  fifth() {
+    return "femte";
+  }
+  first() {
+    return "første";
+  }
+  firstWeekday() {
+    return "første vekedag";
+  }
+  fourth() {
+    return "fjerde";
+  }
+  minutesX0ThroughX1PastTheHour() {
+    return "minutta frå %s til og med %s etter timen";
+  }
+  second() {
+    return "andre";
+  }
+  secondsX0ThroughX1PastTheMinute() {
+    return "sekunda frå %s til og med %s etter minuttet";
+  }
+  spaceAnd() {
+    return " og";
+  }
+  spaceX0OfTheMonth() {
+    return " %s i månaden";
+  }
+  lastDay() {
+    return "den siste dagen";
+  }
+  third() {
+    return "tredje";
+  }
+  weekdayNearestDayX0() {
+    return "vekedag nærmast dag %s";
+  }
+  commaStartingX0() {
+    return ", startar %s";
+  }
+  daysOfTheWeek() {
+    return ["sundag", "måndag", "tysdag", "onsdag", "torsdag", "fredag", "laurdag"];
+  }
+  monthsOfTheYear() {
+    return [
+      "januar",
+      "februar",
+      "mars",
+      "april",
+      "mai",
+      "juni",
+      "juli",
+      "august",
+      "september",
+      "oktober",
+      "november",
+      "desember",
+    ];
+  }
+
+  onTheHour() {
+    return "på timen";
+  }
+}


### PR DESCRIPTION
cronstrue ships Norwegian Bokmål (`nb`) but not Nynorsk, Norway's second official written standard. This adds an `nn` locale.

`nn.ts` mirrors `nb.ts` exactly in structure, with the strings adapted to Nynorsk (e.g. *hver→kvar/kvart, uke→veke, måned→månad, fra→frå, bare→berre, søndag→sundag, tirsdag→tysdag*, and plural forms like *minutter→minutt*). It's registered in `allLocales.ts`; the loader picks it up automatically.

I'm a native Norwegian speaker and reviewed it. Translation was done with AI assistance (Claude) and checked by me; I'm more fluent in Bokmål than Nynorsk, so a Nynorsk reviewer's pass is welcome. Happy to add a locale test file if you'd like.