### PR TITLE
Sync nb/nn with en "in a month" clarification

### DIFF
--- a/src/i18n/locales/nb.ts
+++ b/src/i18n/locales/nb.ts
@@ -45,7 +45,7 @@ export class nb implements Locale {
     return ", hver dag";
   }
   commaEveryX0Days() {
-    return ", hver %s dag";
+    return ", hver %s dag i måneden";
   }
   commaEveryX0DaysOfTheWeek() {
     return ", hver %s ukedag";

--- a/src/i18n/locales/nn.ts
+++ b/src/i18n/locales/nn.ts
@@ -45,7 +45,7 @@ export class nn implements Locale {
     return ", kvar dag";
   }
   commaEveryX0Days() {
-    return ", kvar %s dag";
+    return ", kvar %s dag i månaden";
   }
   commaEveryX0DaysOfTheWeek() {
     return ", kvar %s vekedag";


### PR DESCRIPTION
Small follow-up to keep the Norwegian locales in sync with `en`.

In #369 the English `commaEveryX0Days` was clarified to "every %s days **in a month**" to distinguish day-of-month step expressions. This applies the same clarification to both Norwegian locales:

- `nb.ts`: ", hver %s dag" → ", hver %s dag i måneden"
- `nn.ts`: ", kvar %s dag" → ", kvar %s dag i månaden"

No other strings changed. As a native Norwegian (Bokmål) speaker I'm happy to keep `nb`/`nn` in sync going forward whenever `en` phrasing changes — just let me know if a hand with the Norwegian locales is ever useful.

Disclosure: prepared with AI assistance and reviewed by a native Norwegian speaker.