### PR TITLE
fix(ja): scope day-of-month step description to a month

### DIFF
--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -116,7 +116,7 @@ export class ja implements Locale {
     return "月の %s に";
   }
   commaEveryX0Days(): string {
-    return "、%s 日ごと";
+    return "、月のうち %s 日ごと";
   }
   commaBetweenDayX0AndX1OfTheMonth(): string {
     return "、月の %s 日から %s 日の間";

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -403,6 +403,17 @@ describe("i18n", function () {
     });
   });
 
+  describe("ja", function () {
+    it("0 0 14 */30 * *", function () {
+      // Day-of-month step is scoped to a single month, matching the day-of-week
+      // step which already reads "週のうち %s 日ごと".
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "ja" }),
+        "次において実施14:00、月のうち 30 日ごと"
+      );
+    });
+  });
+
   describe("ko", function () {
     it("* * * * *", function () {
       assert.equal(cronstrue.toString(this.test?.title as string, { locale: "ko" }), "1분마다");


### PR DESCRIPTION
The Japanese day-of-month step description reads like a continuous interval. `0 0 14 */30 * *` renders as:

> 次において実施14:00、30 日ごと   ("... every 30 days")

A day-of-month step restarts every month, though, so the count is bounded to a single month. The day-of-week sibling already makes that scope explicit:

```ts
commaEveryX0DaysOfTheWeek() {
  return "、週のうち %s 日ごと"; // every %s days in the week
}
```

The day-of-month entry was the one left without an equivalent scope:

```ts
commaEveryX0Days() {
  return "、%s 日ごと";
}
```

This adds the parallel `月のうち` (in the month) so the two read consistently:

> 次において実施14:00、月のうち 30 日ごと

It mirrors the clarification added to `en` in #369 ("every %s days **in a month**") and synced to `nb`/`nn` in #396 (`i måneden` / `i månaden`); `ja` was not updated at the time.

I also added a small regression test in a new `ja` block in `test/i18n.ts`. The full suite is green (319 passing).
