### PR TITLE
fix(sl): remove stray %s placeholder from last-day-of-month phrase

### DIFF
--- a/src/i18n/locales/sl.ts
+++ b/src/i18n/locales/sl.ts
@@ -60,7 +60,7 @@ export class sl implements Locale {
     return ", ";
   }
   commaOnTheLastDayOfTheMonth() {
-    return ", zadnji %s v mesecu";
+    return ", zadnji dan v mesecu";
   }
   commaOnTheLastWeekdayOfTheMonth() {
     return ", zadnji delovni dan v mesecu";

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -388,6 +388,15 @@ describe("i18n", function () {
         "Vsakih 5 minut, od 15:00 do 15:59, od Ponedeljek do Petek"
       );
     });
+
+    it("*/5 * L JAN *", function () {
+      // Last day of month takes no value, so the phrase reads "zadnji dan",
+      // matching the sibling commaOnTheLastWeekdayOfTheMonth ("zadnji delovni dan").
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "sl" }),
+        "Vsakih 5 minut, zadnji dan v mesecu, samo v januar"
+      );
+    });
   });
 
   describe("ca", function () {


### PR DESCRIPTION
The Slovenian `commaOnTheLastDayOfTheMonth()` returns `", zadnji %s v mesecu"`, but the `"L"` day-of-month case in `getDayOfMonthDescription()` calls it with no value (unlike `commaOnTheLastX0OfTheMonth()` a few lines below, which is wrapped in `StringUtilities.format`). The `%s` is therefore never substituted and leaks into the output:

```js
cronstrue.toString("0 0 12 L * ?", { locale: "sl" })
// before: "Ob 12:00, zadnji %s v mesecu"
// after:  "Ob 12:00, zadnji dan v mesecu"
```

Every other locale returns a static phrase for this method (en: `", on the last day of the month"`), and the sibling `commaOnTheLastWeekdayOfTheMonth()` in the same file already reads `", zadnji delovni dan v mesecu"`, so the plain day form is `", zadnji dan v mesecu"`.

Added an `it("*/5 * L JAN *")` case under the existing `sl` describe block. `npm test` passes (320).
